### PR TITLE
chore: rename todo-app to notes-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aws-sdk-js-notes-app
 
-In this app, you are going to build a simple todo application using
+In this app, you are going to build a simple note taking application using
 [modular AWS SDK for JavaScript][modular-aws-sdk-js-blog-post]
 
 ## Table of Contents
@@ -18,7 +18,7 @@ In this app, you are going to build a simple todo application using
 
 ## Prerequisites
 
-To set up this todo app, complete the following tasks:
+To set up this notes app, complete the following tasks:
 
 - Install **Node.js** by following these steps:
   1. Install [nvm](https://github.com/nvm-sh/nvm#installation-and-update).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aws-sdk-js-todo-app
+# aws-sdk-js-notes-app
 
 In this app, you are going to build a simple todo application using
 [modular AWS SDK for JavaScript][modular-aws-sdk-js-blog-post]

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-sdk-todo-app/backend",
+  "name": "@aws-sdk-notes-app/backend",
   "version": "1.0.0",
   "private": true,
   "description": "Backend for todo app created using modular AWS SDK for JavaScript",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -2,7 +2,7 @@
   "name": "@aws-sdk-notes-app/backend",
   "version": "1.0.0",
   "private": true,
-  "description": "Backend for todo app created using modular AWS SDK for JavaScript",
+  "description": "Backend for notes app created using modular AWS SDK for JavaScript",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.4.1"
   },

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -25,11 +25,11 @@ Ensure that you've followed pre-requisites from main [README](../../README.md), 
 
 - `yarn prepare:frontend` to populate Cloudformation resources in frontend config.
 - The resources can also be manually added in [`src/config.json`](./src/config.json).
-  - Add `aws-js-sdk-todo-app.GatewayUrl` from CDK output for `GATEWAY_URL`.
+  - Add `aws-js-sdk-notes-app.GatewayUrl` from CDK output for `GATEWAY_URL`.
     - Example GatewayURL: `https://randomstring.execute-api.us-west-2.amazonaws.com/prod/`
-  - Add `aws-js-sdk-todo-app.IdentityPoolId` from CDK output for `IDENTITY_POOL_ID`.
+  - Add `aws-js-sdk-notes-app.IdentityPoolId` from CDK output for `IDENTITY_POOL_ID`.
     - Example IdentityPoolId: `us-west-2:random-strc-4ce1-84ee-9a429f9b557e`
-  - Add `aws-js-sdk-todo-app.FilesBucket` from CDK output for `FILES_BUCKET`.
+  - Add `aws-js-sdk-notes-app.FilesBucket` from CDK output for `FILES_BUCKET`.
 - `yarn start:frontend` to run the server.
   - This will open the website in the browser, and enable HMR.
   - Just edit and save the files in `packages/frontend/src`, and the browser page will auto-refresh!

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@aws-sdk-notes-app/frontend",
   "version": "0.1.0",
   "private": true,
-  "description": "Frontend for todo app created using modular AWS SDK for JavaScript",
+  "description": "Frontend for notes app created using modular AWS SDK for JavaScript",
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "3.4.1",
     "@aws-sdk/client-s3": "3.4.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-sdk-todo-app/frontend",
+  "name": "@aws-sdk-notes-app/frontend",
   "version": "0.1.0",
   "private": true,
   "description": "Frontend for todo app created using modular AWS SDK for JavaScript",

--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -7,11 +7,11 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="ToDo App - modular AWS SDK for JavaScript (v3)"
+      content="Notes App - modular AWS SDK for JavaScript (v3)"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>ToDo App - modular AWS SDK for JavaScript (v3)</title>
+    <title>Notes App - modular AWS SDK for JavaScript (v3)</title>
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"

--- a/packages/infra/cdk.json
+++ b/packages/infra/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "npx ts-node cdk/aws-sdk-js-todo-app.ts"
+  "app": "npx ts-node cdk/aws-sdk-js-notes-app.ts"
 }

--- a/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
+++ b/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
@@ -6,7 +6,7 @@ import * as cognito from "@aws-cdk/aws-cognito";
 import * as iam from "@aws-cdk/aws-iam";
 import { NotesApi } from "./notes-api";
 
-export class AwsSdkJsTodoAppStack extends cdk.Stack {
+export class AwsSdkJsNotesAppStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 

--- a/packages/infra/cdk/aws-sdk-js-notes-app.ts
+++ b/packages/infra/cdk/aws-sdk-js-notes-app.ts
@@ -1,0 +1,5 @@
+import * as cdk from "@aws-cdk/core";
+import { AwsSdkJsNotesAppStack } from "./aws-sdk-js-notes-app-stack";
+
+const app = new cdk.App();
+new AwsSdkJsNotesAppStack(app, "aws-sdk-js-notes-app");

--- a/packages/infra/cdk/aws-sdk-js-todo-app.ts
+++ b/packages/infra/cdk/aws-sdk-js-todo-app.ts
@@ -1,5 +1,0 @@
-import * as cdk from "@aws-cdk/core";
-import { AwsSdkJsTodoAppStack } from "./aws-sdk-js-notes-app-stack";
-
-const app = new cdk.App();
-new AwsSdkJsTodoAppStack(app, "aws-sdk-js-notes-app");

--- a/packages/infra/cdk/aws-sdk-js-todo-app.ts
+++ b/packages/infra/cdk/aws-sdk-js-todo-app.ts
@@ -1,5 +1,5 @@
 import * as cdk from "@aws-cdk/core";
-import { AwsSdkJsTodoAppStack } from "./aws-sdk-js-todo-app-stack";
+import { AwsSdkJsTodoAppStack } from "./aws-sdk-js-notes-app-stack";
 
 const app = new cdk.App();
-new AwsSdkJsTodoAppStack(app, "aws-sdk-js-todo-app");
+new AwsSdkJsTodoAppStack(app, "aws-sdk-js-notes-app");

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-sdk-todo-app/infra",
+  "name": "@aws-sdk-notes-app/infra",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/packages/scripts/populate-frontend-config.js
+++ b/packages/scripts/populate-frontend-config.js
@@ -29,7 +29,7 @@ const { readFileSync, writeFileSync, unlinkSync } = require("fs");
   try {
     const configContents = JSON.parse(readFileSync(configFile));
     const cdkOutput = JSON.parse(readFileSync(cdkOutputsFile))[
-      "aws-sdk-js-todo-app"
+      "aws-sdk-js-notes-app"
     ];
     configContents.GATEWAY_URL = cdkOutput.GatewayUrl;
     configContents.IDENTITY_POOL_ID = cdkOutput.IdentityPoolId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,9 +729,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk-todo-app/backend@workspace:packages/backend":
+"@aws-sdk-notes-app/backend@workspace:packages/backend":
   version: 0.0.0-use.local
-  resolution: "@aws-sdk-todo-app/backend@workspace:packages/backend"
+  resolution: "@aws-sdk-notes-app/backend@workspace:packages/backend"
   dependencies:
     "@aws-sdk/client-dynamodb": 3.4.1
     "@types/aws-lambda": ^8.10.64
@@ -749,9 +749,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk-todo-app/frontend@workspace:packages/frontend":
+"@aws-sdk-notes-app/frontend@workspace:packages/frontend":
   version: 0.0.0-use.local
-  resolution: "@aws-sdk-todo-app/frontend@workspace:packages/frontend"
+  resolution: "@aws-sdk-notes-app/frontend@workspace:packages/frontend"
   dependencies:
     "@aws-sdk/client-cognito-identity": 3.4.1
     "@aws-sdk/client-s3": 3.4.1
@@ -773,9 +773,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk-todo-app/infra@workspace:packages/infra":
+"@aws-sdk-notes-app/infra@workspace:packages/infra":
   version: 0.0.0-use.local
-  resolution: "@aws-sdk-todo-app/infra@workspace:packages/infra"
+  resolution: "@aws-sdk-notes-app/infra@workspace:packages/infra"
   dependencies:
     "@aws-cdk/aws-apigateway": 1.87.1
     "@aws-cdk/aws-cognito": 1.87.1


### PR DESCRIPTION
### Issue

N/A

### Description

Rename todo-app to notes-app.
The original plan was to create a ToDo app, as it is most common apps to start with. But we'll stick with Notes app as of now

### Testing

Verified that backend, frontend and infra are working fine.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
