### PR TITLE
feat(frontend): read region from config 

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -22,9 +22,9 @@ Ensure that you've followed pre-requisites from main [README](../../README.md).
 ### Test backend API
 
 - Open the GatewayUrl link from CDK output from the console.
-  - It'll be like: https://randomstring.execute-api.us-west-2.amazonaws.com/prod/
+  - It'll be like: https://randomstring.execute-api.region.amazonaws.com/prod/
 - Append `notes` in the URL.
-  - It'll be like: https://randomstring.execute-api.us-west-2.amazonaws.com/prod/notes
+  - It'll be like: https://randomstring.execute-api.region.amazonaws.com/prod/notes
 - The contents of the notes DynamoDB table would be returned as JSON.
 - If you don't see anything, that's because your table is likely empty! Add data manually or wait until you run the frontend.
 

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -25,11 +25,12 @@ Ensure that you've followed pre-requisites from main [README](../../README.md), 
 
 - `yarn prepare:frontend` to populate Cloudformation resources in frontend config.
 - The resources can also be manually added in [`src/config.json`](./src/config.json).
+  - Add `aws-js-sdk-notes-app.FilesBucket` from CDK output for `FILES_BUCKET`.
   - Add `aws-js-sdk-notes-app.GatewayUrl` from CDK output for `GATEWAY_URL`.
     - Example GatewayURL: `https://randomstring.execute-api.us-west-2.amazonaws.com/prod/`
   - Add `aws-js-sdk-notes-app.IdentityPoolId` from CDK output for `IDENTITY_POOL_ID`.
     - Example IdentityPoolId: `us-west-2:random-strc-4ce1-84ee-9a429f9b557e`
-  - Add `aws-js-sdk-notes-app.FilesBucket` from CDK output for `FILES_BUCKET`.
+  - Add `aws-js-sdk-notes-app.region` from CDK output for `REGION`.
 - `yarn start:frontend` to run the server.
   - This will open the website in the browser, and enable HMR.
   - Just edit and save the files in `packages/frontend/src`, and the browser page will auto-refresh!

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -30,7 +30,7 @@ Ensure that you've followed pre-requisites from main [README](../../README.md), 
     - Example GatewayURL: `https://randomstring.execute-api.region.amazonaws.com/prod/`
   - Add `aws-js-sdk-notes-app.IdentityPoolId` from CDK output for `IDENTITY_POOL_ID`.
     - Example IdentityPoolId: `region:random-strc-4ce1-84ee-9a429f9b557e`
-  - Add `aws-js-sdk-notes-app.region` from CDK output for `REGION`.
+  - Add `aws-js-sdk-notes-app.Region` from CDK output for `REGION`.
 - `yarn start:frontend` to run the server.
   - This will open the website in the browser, and enable HMR.
   - Just edit and save the files in `packages/frontend/src`, and the browser page will auto-refresh!

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -27,9 +27,9 @@ Ensure that you've followed pre-requisites from main [README](../../README.md), 
 - The resources can also be manually added in [`src/config.json`](./src/config.json).
   - Add `aws-js-sdk-notes-app.FilesBucket` from CDK output for `FILES_BUCKET`.
   - Add `aws-js-sdk-notes-app.GatewayUrl` from CDK output for `GATEWAY_URL`.
-    - Example GatewayURL: `https://randomstring.execute-api.us-west-2.amazonaws.com/prod/`
+    - Example GatewayURL: `https://randomstring.execute-api.region.amazonaws.com/prod/`
   - Add `aws-js-sdk-notes-app.IdentityPoolId` from CDK output for `IDENTITY_POOL_ID`.
-    - Example IdentityPoolId: `us-west-2:random-strc-4ce1-84ee-9a429f9b557e`
+    - Example IdentityPoolId: `region:random-strc-4ce1-84ee-9a429f9b557e`
   - Add `aws-js-sdk-notes-app.region` from CDK output for `REGION`.
 - `yarn start:frontend` to run the server.
   - This will open the website in the browser, and enable HMR.

--- a/packages/frontend/src/config.json
+++ b/packages/frontend/src/config.json
@@ -1,7 +1,7 @@
 {
+  "FILES_BUCKET": "<copy-output-FilesBucket-from-cdk-deploy>",
   "GATEWAY_URL": "<copy-output-GatewayUrl-from-cdk-deploy>",
   "IDENTITY_POOL_ID": "<copy-output-IdentityPoolId-from-cdk-deploy>",
-  "FILES_BUCKET": "<copy-output-FilesBucket-from-cdk-deploy>",
   "REGION": "<copy-output-Region-from-cdk-deploy>",
   "MAX_FILE_SIZE": 2000000
 }

--- a/packages/frontend/src/config.json
+++ b/packages/frontend/src/config.json
@@ -2,5 +2,6 @@
   "GATEWAY_URL": "<copy-output-GatewayUrl-from-cdk-deploy>",
   "IDENTITY_POOL_ID": "<copy-output-IdentityPoolId-from-cdk-deploy>",
   "FILES_BUCKET": "<copy-output-FilesBucket-from-cdk-deploy>",
+  "REGION": "<copy-output-Region-from-cdk-deploy>",
   "MAX_FILE_SIZE": 2000000
 }

--- a/packages/frontend/src/libs/s3Client.ts
+++ b/packages/frontend/src/libs/s3Client.ts
@@ -1,12 +1,12 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { fromCognitoIdentityPool } from "@aws-sdk/credential-provider-cognito-identity";
 import { CognitoIdentityClient } from "@aws-sdk/client-cognito-identity";
-import { IDENTITY_POOL_ID } from "../config.json";
+import { IDENTITY_POOL_ID, REGION } from "../config.json";
 
 const s3Client = new S3Client({
-  region: "us-west-2",
+  region: REGION,
   credentials: fromCognitoIdentityPool({
-    client: new CognitoIdentityClient({ region: "us-west-2" }),
+    client: new CognitoIdentityClient({ region: REGION }),
     identityPoolId: IDENTITY_POOL_ID,
   }),
 });

--- a/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
+++ b/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
@@ -113,6 +113,7 @@ export class AwsSdkJsNotesAppStack extends cdk.Stack {
       },
     });
 
+    new cdk.CfnOutput(this, "Region", { value: this.region });
     new cdk.CfnOutput(this, "GatewayUrl", { value: api.url });
     new cdk.CfnOutput(this, "IdentityPoolId", { value: identityPool.ref });
     new cdk.CfnOutput(this, "FilesBucket", { value: filesBucket.bucketName });

--- a/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
+++ b/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
@@ -113,9 +113,9 @@ export class AwsSdkJsNotesAppStack extends cdk.Stack {
       },
     });
 
-    new cdk.CfnOutput(this, "Region", { value: this.region });
+    new cdk.CfnOutput(this, "FilesBucket", { value: filesBucket.bucketName });
     new cdk.CfnOutput(this, "GatewayUrl", { value: api.url });
     new cdk.CfnOutput(this, "IdentityPoolId", { value: identityPool.ref });
-    new cdk.CfnOutput(this, "FilesBucket", { value: filesBucket.bucketName });
+    new cdk.CfnOutput(this, "Region", { value: this.region });
   }
 }

--- a/packages/scripts/populate-frontend-config.js
+++ b/packages/scripts/populate-frontend-config.js
@@ -31,9 +31,9 @@ const { readFileSync, writeFileSync, unlinkSync } = require("fs");
     const cdkOutput = JSON.parse(readFileSync(cdkOutputsFile))[
       "aws-sdk-js-notes-app"
     ];
+    configContents.FILES_BUCKET = cdkOutput.FilesBucket;
     configContents.GATEWAY_URL = cdkOutput.GatewayUrl;
     configContents.IDENTITY_POOL_ID = cdkOutput.IdentityPoolId;
-    configContents.FILES_BUCKET = cdkOutput.FilesBucket;
     configContents.REGION = cdkOutput.Region;
     writeFileSync(configFile, JSON.stringify(configContents, null, 2));
   } catch (error) {

--- a/packages/scripts/populate-frontend-config.js
+++ b/packages/scripts/populate-frontend-config.js
@@ -34,6 +34,7 @@ const { readFileSync, writeFileSync, unlinkSync } = require("fs");
     configContents.GATEWAY_URL = cdkOutput.GatewayUrl;
     configContents.IDENTITY_POOL_ID = cdkOutput.IdentityPoolId;
     configContents.FILES_BUCKET = cdkOutput.FilesBucket;
+    configContents.REGION = cdkOutput.Region;
     writeFileSync(configFile, JSON.stringify(configContents, null, 2));
   } catch (error) {
     console.log(`Error while updating config.json: ${error}`);


### PR DESCRIPTION
### Issue

N/A

### Description

The region was hardcoded in frontend s3Client. This PR makes region configurable, and it's read from the output of infrastructure code.

### Testing

Verified that frontend works in local run.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
