### PR TITLE
fix: use temporary variable to store partial transcriptions

### DIFF
--- a/packages/frontend/src/content/RecordAudioButton.tsx
+++ b/packages/frontend/src/content/RecordAudioButton.tsx
@@ -61,7 +61,7 @@ const RecordAudioButton = (props: {
           // fix encoding for accented characters.
           const decodedTranscript = decodeURIComponent(escape(Transcript));
           // update noteContent with the latest result.
-          setNoteContent(noteContent + decodedTranscript + "\n");
+          setNoteContent((noteContent: any) => noteContent + decodedTranscript);
         }
       }
     };

--- a/packages/frontend/src/content/RecordAudioButton.tsx
+++ b/packages/frontend/src/content/RecordAudioButton.tsx
@@ -51,21 +51,6 @@ const RecordAudioButton = (props: {
   };
 
   const streamAudioToWebSocket = async (micStream: any) => {
-    const handleEventStreamMessage = (messageJson: any) => {
-      let results = messageJson.Transcript.Results;
-
-      if (results.length > 0) {
-        if (results[0].Alternatives.length > 0) {
-          const { Transcript } = results[0].Alternatives[0];
-
-          // fix encoding for accented characters.
-          const decodedTranscript = decodeURIComponent(escape(Transcript));
-          // update noteContent with the latest result.
-          setNoteContent((noteContent: any) => noteContent + decodedTranscript);
-        }
-      }
-    };
-
     const pcmEncodeChunk = (audioChunk: any) => {
       const raw = MicrophoneStream.toRaw(audioChunk);
       if (raw == null) return;
@@ -83,10 +68,33 @@ const RecordAudioButton = (props: {
     );
 
     if (TranscriptResultStream) {
+      let transcription = "";
       for await (const event of TranscriptResultStream) {
         if (event.TranscriptEvent) {
-          const message = event.TranscriptEvent;
-          handleEventStreamMessage(message);
+          const { Results: results } = event.TranscriptEvent.Transcript || {};
+
+          if (results && results.length > 0) {
+            if (
+              results[0]?.Alternatives &&
+              results[0]?.Alternatives?.length > 0
+            ) {
+              const { Transcript } = results[0].Alternatives[0];
+
+              const prevTranscription = transcription;
+              // fix encoding for accented characters.
+              transcription = decodeURIComponent(escape(Transcript || ""));
+
+              setNoteContent(
+                (noteContent: any) =>
+                  noteContent.replace(prevTranscription, "") + transcription
+              );
+
+              // if this transcript segment is final, reset transcription
+              if (!results[0].IsPartial) {
+                transcription = "";
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-notes-app/issues/11

### Description

Uses temporary variable to store transcriptions, and removes partial transcriptions from the state.

### Testing

<details>
<summary>Screen recording</summary>


https://user-images.githubusercontent.com/16024985/106825138-110a7880-6639-11eb-9a23-faf915fe4d44.mov


</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
