### PR TITLE
chore: clean up eslint warnings in RecordAudioButton

### DIFF
--- a/packages/frontend/src/content/CreateNote.tsx
+++ b/packages/frontend/src/content/CreateNote.tsx
@@ -66,7 +66,6 @@ const CreateNote = (props: RouteComponentProps) => {
         <RecordAudioButton
           isRecording={isRecording}
           setIsRecording={setIsRecording}
-          noteContent={noteContent}
           setNoteContent={setNoteContent}
         />
         <Form.Group controlId="file">

--- a/packages/frontend/src/content/RecordAudioButton.tsx
+++ b/packages/frontend/src/content/RecordAudioButton.tsx
@@ -67,7 +67,7 @@ const RecordAudioButton = (props: {
     );
 
     if (TranscriptResultStream) {
-      let transcription = "";
+      let partialTranscription = "";
       for await (const event of TranscriptResultStream) {
         if (event.TranscriptEvent) {
           const { Results: results } = event.TranscriptEvent.Transcript || {};
@@ -79,18 +79,20 @@ const RecordAudioButton = (props: {
             ) {
               const { Transcript } = results[0].Alternatives[0];
 
-              const prevTranscription = transcription;
+              const transcriptionToRemove = partialTranscription;
               // fix encoding for accented characters.
-              transcription = decodeURIComponent(escape(Transcript || ""));
+              const transcription = decodeURIComponent(escape(Transcript || ""));
 
               setNoteContent(
                 (noteContent: any) =>
-                  noteContent.replace(prevTranscription, "") + transcription
+                  noteContent.replace(transcriptionToRemove, "") + transcription
               );
 
               // if this transcript segment is final, reset transcription
               if (!results[0].IsPartial) {
-                transcription = "";
+                partialTranscription = "";
+              } else {
+                partialTranscription = transcription;
               }
             }
           }

--- a/packages/frontend/src/content/RecordAudioButton.tsx
+++ b/packages/frontend/src/content/RecordAudioButton.tsx
@@ -11,10 +11,9 @@ import { getStreamTranscriptionResponse } from "../libs/getStreamTranscriptionRe
 const RecordAudioButton = (props: {
   isRecording: boolean;
   setIsRecording: Function;
-  noteContent: string;
   setNoteContent: Function;
 }) => {
-  const { isRecording, setIsRecording, noteContent, setNoteContent } = props;
+  const { isRecording, setIsRecording, setNoteContent } = props;
   const [micStream, setMicStream] = useState<any>();
   const [errorMsg, setErrorMsg] = useState("");
 


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/aws-samples/aws-sdk-js-notes-app/pull/14

### Description

Clean up the following eslint warnings in RecordAudioButton:
```console
Compiled with warnings.

src/content/RecordAudioButton.tsx
  Line 17:40:  'noteContent' is assigned a value but never used                                       @typescript-eslint/no-unused-vars
  Line 88:17:  Function declared in a loop contains unsafe references to variable(s) 'transcription'  no-loop-func

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

### Testing

Verified that real-time audio transcription works, and no warnings are shown in console.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
