### PR TITLE
chore: clean-up pcmEncode utility function

### DIFF
--- a/packages/frontend/src/libs/audioUtils.ts
+++ b/packages/frontend/src/libs/audioUtils.ts
@@ -1,10 +1,9 @@
 export const pcmEncode = (input: any) => {
-  var offset = 0;
-  var buffer = new ArrayBuffer(input.length * 2);
-  var view = new DataView(buffer);
-  for (var i = 0; i < input.length; i++, offset += 2) {
-    var s = Math.max(-1, Math.min(1, input[i]));
-    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  const buffer = new ArrayBuffer(input.length * 2);
+  const view = new DataView(buffer);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
   }
   return buffer;
 };


### PR DESCRIPTION
### Issue

N/A

### Description

The original pcmEncode function was picked up from: https://github.com/amazon-archives/amazon-transcribe-websocket-static/blob/6a0b97f1c667b649c31cd9b550c37795a5c7ce25/lib/audioUtils.js#L1-L10

This PR cleans it up by using let/const instead of var, and removing redundant variables.

### Testing

Verified that real-time audio transcription works.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
