### PR TITLE
chore: consume types from microphone-stream package

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/util-create-request": "3.4.1",
     "@aws-sdk/util-format-url": "3.4.1",
     "@reach/router": "1.3.4",
-    "microphone-stream": "5.1.0",
+    "microphone-stream": "5.2.0",
     "react": "17.0.1",
     "react-bootstrap": "1.4.0",
     "react-dom": "17.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,7 +767,7 @@ __metadata:
     "@types/react": 17.0.0
     "@types/react-dom": 17.0.0
     local-web-server: ^4.2.1
-    microphone-stream: 5.1.0
+    microphone-stream: 5.2.0
     react: 17.0.1
     react-bootstrap: 1.4.0
     react-bootstrap-icons: 1.3.0
@@ -15105,13 +15105,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"microphone-stream@npm:5.1.0":
-  version: 5.1.0
-  resolution: "microphone-stream@npm:5.1.0"
+"microphone-stream@npm:5.2.0":
+  version: 5.2.0
+  resolution: "microphone-stream@npm:5.2.0"
   dependencies:
     buffer-from: ^1.1.1
     readable-stream: ^3.6.0
-  checksum: b64869f02fba7e00025d32fcf6bbc2b7ef6f0e52c63e98e2f9a4cf108e9bc2b72c193092e056b1e39fb068aab757cf3a3f5155a74dfedbc8702825d344ca80c8
+  checksum: fc28b6150bac409b6c124411f370b3962acac7c68fa6da04e85795f1d8fb40977de583db4f856d6ba658f692d30a9f5931a308d3fc52cf6d3c9814738815c6f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Consume microphone-stream type definitions added in https://github.com/saebekassebil/microphone-stream/pull/40

### Description

Consume type definitions added in `microphone-stream@5.2.0` and remove `any`

### Testing

Verified that real-time audio transcription is working.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
