### PR TITLE
chore(deps-dev): bump aws-cdk to 1.89.0

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -7,15 +7,15 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigateway": "1.87.1",
-    "@aws-cdk/aws-cognito": "1.87.1",
-    "@aws-cdk/aws-dynamodb": "1.87.1",
-    "@aws-cdk/aws-iam": "1.87.1",
-    "@aws-cdk/aws-lambda": "1.87.1",
-    "@aws-cdk/aws-s3": "1.87.1",
-    "@aws-cdk/core": "1.87.1",
+    "@aws-cdk/aws-apigateway": "1.89.0",
+    "@aws-cdk/aws-cognito": "1.89.0",
+    "@aws-cdk/aws-dynamodb": "1.89.0",
+    "@aws-cdk/aws-iam": "1.89.0",
+    "@aws-cdk/aws-lambda": "1.89.0",
+    "@aws-cdk/aws-s3": "1.89.0",
+    "@aws-cdk/core": "1.89.0",
     "@types/node": "^14.14.2",
-    "aws-cdk": "1.87.1",
+    "aws-cdk": "1.89.0",
     "typescript": "~4.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,674 +5,678 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"@aws-cdk/assets@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/assets@npm:1.87.1"
+"@aws-cdk/assets@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/assets@npm:1.89.0"
   dependencies:
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: adb5f9ef85dd4825973af4183d6475f3f796f518ff83ed201dd751a5680afddf9bcaf4a556a5df2fc5da937d049f20e2b97d093e3f7c94aba46d48c5688a21fd
+  checksum: 878bb476ca4599acc40829d8ae0691799fe4bcbee042402c9aad8bcaed9f6ea93350f5a7da33ddec8fff89432fb4417c3bc9be331563d46bfed97faac2277dbc
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-apigateway@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-apigateway@npm:1.87.1"
+"@aws-cdk/aws-apigateway@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-apigateway@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-elasticloadbalancingv2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-cognito": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-elasticloadbalancingv2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-elasticloadbalancingv2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-cognito": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-elasticloadbalancingv2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: 78181e88815edd3de135f29eb55733c13942b025792e78c5ecdbb0fb3ad423564aecbba883fddc09b89d4d90154684138062443fa5f7b39e50122322bcc3091a
+  checksum: 91c87348c130e58e99631881edd3f7090430b43cde7a6f215ffea6c2cc3dd3c3e2f13e7392278a020c367894259e873339cf722bb9d484107fd0f46d5745746f
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-applicationautoscaling@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-applicationautoscaling@npm:1.87.1"
+"@aws-cdk/aws-applicationautoscaling@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-applicationautoscaling@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-autoscaling-common": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-autoscaling-common": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-autoscaling-common": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-autoscaling-common": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 88b892418e7f90501d6ed5c0df14d45295ab915c7b5654a24289b0dff009ae474dc86a2f836aba9264dda2cbbcc992222b8ad208b1b5e36e31aab1a91b6a6de0
+  checksum: 3c505033567e4c48d8e03215977da5c4062227b897bc18a624df2da6749c3f38dbdb5bb91b85febc8bd0fd8261de1a1e3ae061719a6980b077e98b88bfacdf20
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-autoscaling-common@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-autoscaling-common@npm:1.87.1"
+"@aws-cdk/aws-autoscaling-common@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-autoscaling-common@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 32ff1e14b209ba161c18872a27b6fd684eaff02ba78e495c9a1391e04b556e869411b21f6834496ccd5e7513f1a2d3d74fa51202418a505503fe29351f4cee50
+  checksum: d4bbb614621d69456c2ed607e0a54fa7ca3e492ff83440f5401be46f5952594ed446a13bb785d0cb6e15a04af735c7283197bc37a53c205c3df42b0410f8247a
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-certificatemanager@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-certificatemanager@npm:1.87.1"
+"@aws-cdk/aws-certificatemanager@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-certificatemanager@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-route53": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-route53": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-route53": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-route53": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 106a63ddae45be261f92f6275ef2d155b0f1abee82c36c97e6a6b67d814e18bc1d367bc7c2f37e26a95ab0b2e00ded0153ae424546a0a206316653c4c6dbf89d
+  checksum: 2d71e4e9492ce31b68e9aab27c1fd1328835b2206068cd6fcd13bf151fab27664bea4b0484300a7d4969da8cccc4e37af5732eab34d5ef9f59f15119cdcd9a94
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-cloudformation@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-cloudformation@npm:1.87.1"
+"@aws-cdk/aws-cloudformation@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-cloudformation@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-sns": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-sns": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-sns": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-sns": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: 58f770ba99e8f4567df323622b66803ac32d49c83b5ff90a404d185f96f572467c823b3af7bf8bc62dff0208929acc9a048222ba9dcee95b218a9002b974e4de
+  checksum: 55b37d09a51a727a0903e4d017aaa6d1fea5ebaf6fdbb86dee1fdc193daf30972db375309753b4958e8232755056475f8dc164c7ff0a13d41012577262986ae5
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-cloudwatch@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-cloudwatch@npm:1.87.1"
+"@aws-cdk/aws-cloudwatch@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-cloudwatch@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: e60bc1d0546afe874e753472c3dd946e8bc5b99edc10201bada1631cd4bc4815284b61f4042c6e0bdf452045b9bb6b6f303dfa4aa02f03189d0ecbc464bcf163
+  checksum: 9c20d1f4e0ae38b1f9b83fad3a39facfe7945cceb6456093c270919b07f723563652739fddef6b61211ea2e245f579909ec0dc50d6fe42850eef694e50113313
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-codeguruprofiler@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-codeguruprofiler@npm:1.87.1"
+"@aws-cdk/aws-codeguruprofiler@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-codeguruprofiler@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 977a46db647a72f06e62b2ee4c3cfdaecf93d22d8ed2ee26e51a342a98aca14caabbceccef97de4cf28e19687cf6e555fabf621cf2c5e2da08f8c8083fed2f7b
+  checksum: b133e8ff10d1cc5a9969a9a03a8910ce4140172b50948250c5a87c239afa37420a66ba9e91bf40af20f7b892179da756d23eaf96454d4a6555e69722aeee8152
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-cognito@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-cognito@npm:1.87.1"
+"@aws-cdk/aws-cognito@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-cognito@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
     punycode: ^2.1.1
   peerDependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
-  checksum: 21bc5ce0b8cc2f38ba173f552aa5b28629f3abe5cec5c059db310b5befa7bdce94ee5e7b7d6750c803b48a9426e3be07a4aa7c41d8568e9fd988c899d751f884
+  checksum: 61a728028e791cfc2833147ef58e8f42f1a11d1152c958f10b2f70a20196c29ef029341c6fe8cd946e2f9e554a346282b4fd919acaae7c85a8615e42ff9cf4bf
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-dynamodb@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-dynamodb@npm:1.87.1"
+"@aws-cdk/aws-dynamodb@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-dynamodb@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-applicationautoscaling": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-applicationautoscaling": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-applicationautoscaling": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
-  checksum: 0a0c9277f99a08fad9054a615a95d4ce60ad7d691c913442ecb1a0b369e8432a85afdbcdffbf0476e2e7526b91b78ee71af11b931e78ae4d00abf02fea2c28da
+  checksum: 765d16ed822e20b5eb3d34bc1f8b338f2883df05a3ab30b478cda8fbe447d8860fa0d921863b57cc9e6315c0aee42f3d99d2d452f77ae61d7343317e50c20b25
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-ec2@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-ec2@npm:1.87.1"
+"@aws-cdk/aws-ec2@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-ec2@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/aws-ssm": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/aws-ssm": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/aws-ssm": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/aws-ssm": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
-  checksum: 56b367eea2d7f960f183ed15e5498741cf3467ac28f1d1ee23356084266b124d90ba6f9f308494040f03619938a47f28b2a31d5da106d528bfe2455ca79a8290
+  checksum: 406f5d9270d6e295e6f2088ce79bebec6517afd8aa8714c93d7e89171dc57d4e2a474fffe1bd950bc278ce28632d264e557af37e348922d76036caaa8e679ed6
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-ecr-assets@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-ecr-assets@npm:1.87.1"
+"@aws-cdk/aws-ecr-assets@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-ecr-assets@npm:1.89.0"
   dependencies:
-    "@aws-cdk/assets": 1.87.1
-    "@aws-cdk/aws-ecr": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/assets": 1.89.0
+    "@aws-cdk/aws-ecr": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
     minimatch: ^3.0.4
   peerDependencies:
-    "@aws-cdk/assets": 1.87.1
-    "@aws-cdk/aws-ecr": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/assets": 1.89.0
+    "@aws-cdk/aws-ecr": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: 0806b478093eb77be397798f8563f5301f9a30e107554f36efdd814d10109b1054b28cf5d74b74c1b800dbadf3c5755ee1eb77890a7b6e6b49c5d26948d0b7a4
+  checksum: 5799ba68493ae6d0a7eb023da50e0d168df40e22b8a80c28f04912593fcd8e68c840e8ff35a0e21e85bbf18e16b54bc84a4b83344de300574ed32d358102b26c
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-ecr@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-ecr@npm:1.87.1"
+"@aws-cdk/aws-ecr@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-ecr@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 2a60a10de5b3ef9844656acf82ef6fd2ccbb5f6b16e070f328777536f7469815388a506dfb72e71e5b9c8a0134ff0f094b9a1a690434d4546152be979dd4b811
+  checksum: 8d8529e9edecb3a04a4f4721b999c69ae29f6ed02ed1a5d0374030d76f4a7efe56668fd89f19a6241e1e923cdc22c1f2bddacef45c0df7c807817fae3dd01f9a
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-efs@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-efs@npm:1.87.1"
+"@aws-cdk/aws-efs@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-efs@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: ea99538798d9e9f3976fed0e4a2654ac9c5620ee9829134562677a250f151cdbed71e0e893aa130f28522cc86c1a0b8e5731c57a2f753eb2800d3b5489299ad5
+  checksum: 4e49da708c90d7412b5ac6453d0b1704336864eb4f0de3d13f5fbf829554509533a598b2949609079b07ac2d203fffabc4fbe3de85525015113817e9d4badefe
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-elasticloadbalancingv2@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-elasticloadbalancingv2@npm:1.87.1"
+"@aws-cdk/aws-elasticloadbalancingv2@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-elasticloadbalancingv2@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-certificatemanager": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/aws-certificatemanager": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
-  checksum: dccbb5341355831cacf8c149c84a713137542602e18b78c79c6340428f75982da8b61711e7bf36825f49737d17a9633f48adb02395fd226d3d4ab26904e3df53
+  checksum: 38b2ec724871f433d5d9f9a317236f4c65088390592745729fda313d0cf9f042fdce9b87bc61dd3ee98c7af47df59001be27cf59f022108c3fad44f66afc0775
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-events@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-events@npm:1.87.1"
+"@aws-cdk/aws-events@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-events@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 8098d4c18c8f3498d5532ed6a16376a905d01123ae6f9a448c92e166493acac51f2f58cd4d687d2cd11b3b4f6221cc0beb26873d245bf80eca9778074c5c19cb
+  checksum: e96381839a67b16f993baaf14c60f44757be0d4321874ad4e279b97bc703370482824fd0b5c560f1b4555f6731498f336f523bbf8e8c6409709252f97ce64839
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-iam@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-iam@npm:1.87.1"
+"@aws-cdk/aws-iam@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-iam@npm:1.89.0"
   dependencies:
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
-  checksum: 861151d0e14978e040e728f5b5c155fd686e64029751aa9de0152fced2d8cf1d0f3af69abe6f7e3dd9102f1b12286350a540bd443ec4fd564dd05589950a8958
+  checksum: 79a6dc97ba21ba3eb9c52a31f92ff030460e9474551aa1014299c7e528f8220c94d70128f603e6e9cd05a7af07c4b0827f1cef4679db3661bdd23803c5ff5274
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-kms@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-kms@npm:1.87.1"
+"@aws-cdk/aws-kms@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-kms@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: fbbcc38593fc6e67d851b4852b1630c5a8ea2ea2cf5b973fa160f30308d76b95bb7f8b30e740681e7cfcfbbc32e55def87dea0960be7cfca8bfc1ccb1d24c44e
+  checksum: 2da4fe20d0bb592881180484201222d3d2555a12d28f84732be1428fcf56e8b6bcefe656d2d3385ba80e9de09a0e19be23df85e3d9bed661d3ff6d2f69e35727
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-lambda@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-lambda@npm:1.87.1"
+"@aws-cdk/aws-lambda@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-lambda@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-codeguruprofiler": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-ecr": 1.87.1
-    "@aws-cdk/aws-ecr-assets": 1.87.1
-    "@aws-cdk/aws-efs": 1.87.1
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/aws-sqs": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-applicationautoscaling": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-codeguruprofiler": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-ecr": 1.89.0
+    "@aws-cdk/aws-ecr-assets": 1.89.0
+    "@aws-cdk/aws-efs": 1.89.0
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/aws-sqs": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-applicationautoscaling": 1.87.1
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-codeguruprofiler": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-ecr": 1.87.1
-    "@aws-cdk/aws-ecr-assets": 1.87.1
-    "@aws-cdk/aws-efs": 1.87.1
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/aws-sqs": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-applicationautoscaling": 1.89.0
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-codeguruprofiler": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-ecr": 1.89.0
+    "@aws-cdk/aws-ecr-assets": 1.89.0
+    "@aws-cdk/aws-efs": 1.89.0
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/aws-sqs": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: 93dd18f2e7ca2ebf4d6b05203098989ed09f1385812018763f31655be279963f0dfe9644df79f3c69fb1743a3856c7b757da1ee3517c649611962fecfcd2621e
+  checksum: e58f789a1cce7b4474bc40c374a0daa123c3ab4679c623ca82b7d987d0bc94a709095431bf57b565b71f4483701f70ba8b20b3592df673efbe594dd3f7c869ce
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-logs@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-logs@npm:1.87.1"
+"@aws-cdk/aws-logs@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-logs@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-s3-assets": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-s3-assets": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 8c8893cfecfb6732295a7eeab693d7716c6e01c8c10d1a966dfcb1bae4f3569b8b5b9aa336b5ba75007c8f18e68a75371634d57cc21859756a3ea4ff0f09cc85
+  checksum: 40100894293b9bd8efba46c69f77abe7a7f818a13ff3da0338b60c93a599466c338d40379fdf1c0bf7b686e515e2d9f5f5e4082fb2bc1743857601ecae86a5e4
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-route53@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-route53@npm:1.87.1"
+"@aws-cdk/aws-route53@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-route53@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/custom-resources": 1.87.1
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/custom-resources": 1.89.0
     constructs: ^3.2.0
-  checksum: a215ffa7b715c657c344726323d2effa1ce5cbb84d45d3f69673dbf13a26878208fedd358570122a0347f4dab5a5d78ca7b997d340a93113045357562643d4e2
+  checksum: 1a0f60d6bb026f9f032a2e8ff82a15586f2a9cc51c53c9857b06cd03e6891300976d4467ea88c864da7382f4c0371dc91067ee17e38c9ed51cf43690d7d8517c
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-s3-assets@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-s3-assets@npm:1.87.1"
+"@aws-cdk/aws-s3-assets@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-s3-assets@npm:1.89.0"
   dependencies:
-    "@aws-cdk/assets": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/assets": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/assets": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/assets": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: ddd3c91f64e8ebb0f1a4f71c3a37bb6a6eb11d2331da78005af6b4009b34d2ee76fc812add31a2bb5784f27c3e53c5ab5a2f39a40c57be08451991e14fc28f4f
+  checksum: 3b601e0d676ed84e8f9120eae3aa299a5a8ef0d58739ecdc821923b8d79a5d7ffc3215f6389089792cb1b78be306c56f17043ddff4ac09d08be703e20f72d0d3
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-s3@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-s3@npm:1.87.1"
+"@aws-cdk/aws-s3@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-s3@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/core": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/core": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     constructs: ^3.2.0
-  checksum: 6657ab464b5657be00213188697010397e4e9a61941271de246dddd1074ab6b5e8595aad9bfbe9c035a04148dfd57e267f68cfedb961e1c21e31767131426807
+  checksum: c62760afd0ba2466843571e83171958f97cc433d439e03418768497f995221608cd52cbbeedcc25848bf0a24e4be706cf718881ff049f4b2e519faefddf13ceb
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-sns@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-sns@npm:1.87.1"
+"@aws-cdk/aws-sns@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-sns@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-sqs": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-sqs": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-events": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/aws-sqs": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-events": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/aws-sqs": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: ac6c09be2b9c9d00d3147f8a2b113d9177e67e7bed93efaadbe73618f0a0606b73b8f67c89b4b9cf272e9784115033f076a78df53b7272e3d634708eeba47e00
+  checksum: 2b9eafe9e7cf004e8cd3cad62e27940316b209e5ebe03c1e7cba48dd73d8c5a72b5015e46f7dc86f690fba5bdfc8ffad07be2cc9f1466e714dc836c159f326ee
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-sqs@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-sqs@npm:1.87.1"
+"@aws-cdk/aws-sqs@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-sqs@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-cloudwatch": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudwatch": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: 0642bd0b532a2710af7eb0020b27eccd3c1ae205ae04897c5ebf779eda962cf82585558445fc3ebc522231bd9a3a152d362d0576abfdb1a710fdb7a27456efad
+  checksum: 57677a8ec8c6b036394369b8aa81b2a964bc458206b55050da4023d1bc3f31061249199b3c26ec5db2bfef10bf1855c0bf2aa08f53444237a6d9a256b4aefe90
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-ssm@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/aws-ssm@npm:1.87.1"
+"@aws-cdk/aws-ssm@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/aws-ssm@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-kms": 1.87.1
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-kms": 1.89.0
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: c4ad958f9595986573d99f4887ca267673b1e408ee94857dac1cce580c8fa0de71936aa080fd7cf7e17a7d6c454ce5a4f9857dae20425bf12558a10848f43437
+  checksum: f20540245160aa9178df88df9facbd6f73900451c19b8c0d261c0c2ceb8682396404201d599ad688a85eef1e1d585ea45dbc59eca2005631da327015ab331021
   languageName: node
   linkType: hard
 
-"@aws-cdk/cfnspec@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/cfnspec@npm:1.87.1"
+"@aws-cdk/cfnspec@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/cfnspec@npm:1.89.0"
   dependencies:
     md5: ^2.3.0
-  checksum: 795a0ecb867d5e745f7440652999f5bc7ef796022a7d6a30cf1bac8cb069eb4eb66f16dee6759bbd6aa8bbce526eb45169f79c77aca29d87e242e724c301cac5
+  checksum: 4d9ee38ae6ddc1fbd639d1af0f269b7d168cf25ebd742ab9ec55d7155c4196c7e5b6ce0aeb2b8b43fbab9e6d9fde10c8f9ead934cb68e3b41b05499a91785701
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:1.87.1"
+"@aws-cdk/cloud-assembly-schema@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:1.89.0"
   dependencies:
     jsonschema: ^1.4.0
     semver: ^7.3.2
-  checksum: eb356a8623388e081d7d0faed71d443f6190ce6a9bfdc2034f1b7e8e820619414afef29c5eb48706c1eba5e0821086a4d600f02edb82b3e33ce76eba850c8d87
+  checksum: 75d49c5b9d744f7c97bc19862a2c0a3ee88c7a77faad1e59b5003fcfd153b7ea7c42da5cc9d79bf2612da5c06e1478f1f4d51487240f58aeea99de3bfa9da24b
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloudformation-diff@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/cloudformation-diff@npm:1.87.1"
+"@aws-cdk/cloudformation-diff@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/cloudformation-diff@npm:1.89.0"
   dependencies:
-    "@aws-cdk/cfnspec": 1.87.1
+    "@aws-cdk/cfnspec": 1.89.0
     colors: ^1.4.0
     diff: ^5.0.0
     fast-deep-equal: ^3.1.3
     string-width: ^4.2.0
     table: ^6.0.7
-  checksum: 080b331713674ba0b09f9c544af958831aea09843e59da01f352677520079a6809bf66bb694b55a7ab1873cad4d8e0c98f9e9b8d7d0d9bd2fffe4ab6d31d16c3
+  checksum: c2aa379806aba9374514592b7efe6c1ebb9fb014dc8cb4d37c4239d68f97982cb2a278a682a32fa0f7e9b4d7396e228f8634628b880d93fea6b8923f391c79e9
   languageName: node
   linkType: hard
 
-"@aws-cdk/core@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/core@npm:1.87.1"
+"@aws-cdk/core@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/core@npm:1.89.0"
   dependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     "@balena/dockerignore": ^1.0.2
     constructs: ^3.2.0
     fs-extra: ^9.1.0
     ignore: ^5.1.8
     minimatch: ^3.0.4
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
     constructs: ^3.2.0
-  checksum: 9d1ab2396217604c916fe8c6b2dda36fa6866461f2ba7f714707435486b1e1e0b3e8025fc3d33c99111184bf7fd4d06163e11d39a26c79397098278253ba3c72
+  checksum: 0a2368077d76296519a511c78613453fe5b274e90550e8b393d779b4252f3116209e78ed391e56532832f8c57df493b35d7098c8b60dbf0acb94091c37b592f3
   languageName: node
   linkType: hard
 
-"@aws-cdk/custom-resources@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/custom-resources@npm:1.87.1"
+"@aws-cdk/custom-resources@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/custom-resources@npm:1.89.0"
   dependencies:
-    "@aws-cdk/aws-cloudformation": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-sns": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudformation": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-sns": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
   peerDependencies:
-    "@aws-cdk/aws-cloudformation": 1.87.1
-    "@aws-cdk/aws-ec2": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-logs": 1.87.1
-    "@aws-cdk/aws-sns": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-cloudformation": 1.89.0
+    "@aws-cdk/aws-ec2": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-logs": 1.89.0
+    "@aws-cdk/aws-sns": 1.89.0
+    "@aws-cdk/core": 1.89.0
     constructs: ^3.2.0
-  checksum: cbe2d5fe428540f80d7ff387ada86ed5191ccee113998f28a4b8167036994dbcc3c0ea00d58881158c014dd9ef9e6f8dec43deab3cf16b7f28f092b6876713c1
+  checksum: b641fce12b05628e5c8bdb8fc980b22ce75a23c58b17968311ad5fd762c150f1ec242bf17b0a8037c64655e381b80a53ef923cef19bc5985172e5e95ea41827b
   languageName: node
   linkType: hard
 
-"@aws-cdk/cx-api@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/cx-api@npm:1.87.1"
+"@aws-cdk/cx-api@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/cx-api@npm:1.89.0"
   dependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
     semver: ^7.3.2
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-  checksum: 71f14229a8714bc213a800d4b8c26bb343b503b08976c62e19ef2b056855d3758e2abee7d54de75160cecb0b0cd7ba3b7d80974f752808e4b98a2f64174c0789
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+  checksum: a57f0577db3a5f0f1a4f19f519ca300ccfc7519b3fe52f13f9a0a228a0b90fce9c85d414fb75f6fbd05e392e45d97c006a8be6d1d1449d74dd082aa9552e2d66
   languageName: node
   linkType: hard
 
-"@aws-cdk/region-info@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/region-info@npm:1.87.1"
-  checksum: 06082090d5463e7e513845bb5185de1ac725cddd9fc18a7d89351db081f7da6518a6cb9f89acfcbea568a6f2e62f1d9c646d0125189efd9ae545ac4e07c842d9
+"@aws-cdk/region-info@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/region-info@npm:1.89.0"
+  checksum: c03239eac12ed5ee0a2b0c257ea1e7ee4c557623fb24e72fae6499f0718588a1f0bdea4ed61b0d9642ee19bcf48e0b2724faf30e9ae9864560f33970f1f14553
   languageName: node
   linkType: hard
 
-"@aws-cdk/yaml-cfn@npm:1.87.1":
-  version: 1.87.1
-  resolution: "@aws-cdk/yaml-cfn@npm:1.87.1"
+"@aws-cdk/yaml-cfn@npm:1.89.0":
+  version: 1.89.0
+  resolution: "@aws-cdk/yaml-cfn@npm:1.89.0"
   dependencies:
     yaml: 1.10.0
-  checksum: d3cb90f1099488d105c02c4e8c68406e406c92ed9bd11b5433306137ea44386f749cc8835973a23e73bc44ace84d3cf5a7cb5f955d6b87419d63c51938fc967b
+  checksum: 4f3deae3278965dfa9dfb043060a41db59c0919a21c37d8e7ab9b5e55be3edf52f328a46414e4669a1dcaddb0c01d68ff61984a61e256eb1e6d3c35220019904
   languageName: node
   linkType: hard
 
@@ -783,15 +787,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk-notes-app/infra@workspace:packages/infra"
   dependencies:
-    "@aws-cdk/aws-apigateway": 1.87.1
-    "@aws-cdk/aws-cognito": 1.87.1
-    "@aws-cdk/aws-dynamodb": 1.87.1
-    "@aws-cdk/aws-iam": 1.87.1
-    "@aws-cdk/aws-lambda": 1.87.1
-    "@aws-cdk/aws-s3": 1.87.1
-    "@aws-cdk/core": 1.87.1
+    "@aws-cdk/aws-apigateway": 1.89.0
+    "@aws-cdk/aws-cognito": 1.89.0
+    "@aws-cdk/aws-dynamodb": 1.89.0
+    "@aws-cdk/aws-iam": 1.89.0
+    "@aws-cdk/aws-lambda": 1.89.0
+    "@aws-cdk/aws-s3": 1.89.0
+    "@aws-cdk/core": 1.89.0
     "@types/node": ^14.14.2
-    aws-cdk: 1.87.1
+    aws-cdk: 1.89.0
     typescript: ~4.1.2
   languageName: unknown
   linkType: soft
@@ -6767,19 +6771,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk@npm:1.87.1":
-  version: 1.87.1
-  resolution: "aws-cdk@npm:1.87.1"
+"aws-cdk@npm:1.89.0":
+  version: 1.89.0
+  resolution: "aws-cdk@npm:1.89.0"
   dependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/cloudformation-diff": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
-    "@aws-cdk/region-info": 1.87.1
-    "@aws-cdk/yaml-cfn": 1.87.1
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/cloudformation-diff": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
+    "@aws-cdk/region-info": 1.89.0
+    "@aws-cdk/yaml-cfn": 1.89.0
     archiver: ^5.2.0
     aws-sdk: ^2.830.0
     camelcase: ^6.2.0
-    cdk-assets: 1.87.1
+    cdk-assets: 1.89.0
     colors: ^1.4.0
     decamelize: ^5.0.0
     fs-extra: ^9.1.0
@@ -6796,7 +6800,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     cdk: bin/cdk
-  checksum: cb1175263d7e2a889fa8148bdcfa21008a11cc06a2e515c05e6849f07c3b6b47d18fe543b9595e187ca10f072c52a314ebd42e5068cc52530954d15ff14f7aca
+  checksum: e606d0bed943eee4f417066cd811cc5fda1c185094586362b2dcf268d9a39d4e4e6899fff232fd9669e5825af6e496afe2056a08f0f2a9461c94754f9ea1f73c
   languageName: node
   linkType: hard
 
@@ -7749,19 +7753,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdk-assets@npm:1.87.1":
-  version: 1.87.1
-  resolution: "cdk-assets@npm:1.87.1"
+"cdk-assets@npm:1.89.0":
+  version: 1.89.0
+  resolution: "cdk-assets@npm:1.89.0"
   dependencies:
-    "@aws-cdk/cloud-assembly-schema": 1.87.1
-    "@aws-cdk/cx-api": 1.87.1
+    "@aws-cdk/cloud-assembly-schema": 1.89.0
+    "@aws-cdk/cx-api": 1.89.0
     archiver: ^5.2.0
     aws-sdk: ^2.830.0
     glob: ^7.1.6
     yargs: ^16.2.0
   bin:
     cdk-assets: bin/cdk-assets
-  checksum: 384816b452a72b1bae9244866e6e3d4108f7cf75d0ad9ad1e20d355961ece38d56b53ea798ba37ee733edc7e0ff503ad441ca81e25d1f3f9bd1656ae9558554c
+  checksum: fde2714049240a7a0b40d3d857639429b42669091b35ac08252d7e3ae9904bd8997cdbd23989c01c544bcf7565080fb7a9a7e45f4dbf7801ebe372ef306ced6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

To try nodejs14.x runtime on lambda introduced in aws-cdk 1.89.0 https://github.com/aws/aws-cdk/pull/12861

### Description

bumps cdk to 1.89.0

### Testing

```console
$ yarn cdk diff
Stack aws-sdk-js-notes-app
There were no differences
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
