### PR TITLE
feat(backend): use nodejs14.x runtime in lambdas

### DIFF
--- a/packages/infra/cdk/notes-api.ts
+++ b/packages/infra/cdk/notes-api.ts
@@ -19,7 +19,7 @@ export class NotesApi extends cdk.Construct {
     const { table, grantActions } = props;
 
     this.handler = new lambda.Function(this, "handler", {
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: "app.handler",
       // ToDo: find a better way to pass lambda code
       code: lambda.Code.fromAsset(`../backend/dist/${id}`),


### PR DESCRIPTION
### Issue

[aws-cdk@1.89.0](https://github.com/aws/aws-cdk/releases/tag/v1.89.0) now supports nodejs14.x runtime in lambda.

### Description

Upgrades version of Node.js runtime to latest LTS 14.x in Lambda.

### Testing

Verified that notes-app is working as designed.

<details>
<summary>yarn cdk diff</summary>

```console
Stack aws-sdk-js-notes-app
Resources
[~] AWS::Lambda::Function listNotes/handler listNoteshandlerDC187D34 
 └─ [~] Runtime
     ├─ [-] nodejs12.x
     └─ [+] nodejs14.x
[~] AWS::Lambda::Function createNote/handler createNotehandlerBA768AA5 
 └─ [~] Runtime
     ├─ [-] nodejs12.x
     └─ [+] nodejs14.x
[~] AWS::Lambda::Function getNote/handler getNotehandler167C5FCF 
 └─ [~] Runtime
     ├─ [-] nodejs12.x
     └─ [+] nodejs14.x
[~] AWS::Lambda::Function updateNote/handler updateNotehandler6A5A41DF 
 └─ [~] Runtime
     ├─ [-] nodejs12.x
     └─ [+] nodejs14.x
[~] AWS::Lambda::Function deleteNote/handler deleteNotehandlerC903D399 
 └─ [~] Runtime
     ├─ [-] nodejs12.x
     └─ [+] nodejs14.x
```

</details>

<details>
<summary>Lambda console screenshot (nodejs12.x)</summary>

![before](https://user-images.githubusercontent.com/16024985/107539876-43a4fb80-6b7a-11eb-9558-d692d46157db.png)

</details>

<details>
<summary>Lambda console screenshot (nodejs14.x)</summary>

![after](https://user-images.githubusercontent.com/16024985/107539912-4f90bd80-6b7a-11eb-9570-ea2819233fe2.png)

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
