### PR TITLE
chore(infra): remove redundant default DESTROY removalPolicy

### DIFF
--- a/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
+++ b/packages/infra/cdk/aws-sdk-js-notes-app-stack.ts
@@ -12,7 +12,6 @@ export class AwsSdkJsNotesAppStack extends cdk.Stack {
 
     const table = new dynamodb.Table(this, "notes", {
       partitionKey: { name: "noteId", type: dynamodb.AttributeType.STRING },
-      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });
 
     const api = new apigw.RestApi(this, "endpoint");
@@ -69,9 +68,7 @@ export class AwsSdkJsNotesAppStack extends cdk.Stack {
       )
     );
 
-    const filesBucket = new s3.Bucket(this, "files-bucket", {
-      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
-    });
+    const filesBucket = new s3.Bucket(this, "files-bucket");
     filesBucket.addCorsRule({
       allowedOrigins: apigw.Cors.ALL_ORIGINS, // NOT recommended for production code
       allowedMethods: [


### PR DESCRIPTION
### Issue

Refs: https://github.com/aws-samples/aws-sdk-js-notes-app/issues/21

### Description

Remove redundant mention of default DESTROY [removalPolicy](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.RemovalPolicy.html#destroy)

### Testing

Local testing.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
