### PR TITLE
fix(backend): enable tree shaking in esbuild

### DIFF
--- a/packages/backend/build.js
+++ b/packages/backend/build.js
@@ -11,5 +11,6 @@ buildSync({
   outdir: "dist",
   platform: "node",
   target: "node14",
+  mainFields: ["module", "main"],
   logLevel: "info",
 });


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/aws-samples/aws-sdk-js-notes-app/pull/40

### Description

Enable tree shaking in ESBuild by preferring `module` field before `main`.
Docs: https://esbuild.github.io/api/#main-fields

<details>
<summary>Before</summary>

```console
$ yarn build:backend

  dist/updateNote/app.js  498.4kb
  dist/createNote/app.js  498.4kb
  dist/getNote/app.js     498.3kb
  dist/deleteNote/app.js  498.3kb
  dist/listNotes/app.js   498.2kb

⚡ Done in 102ms
```

</details>

<details>
<summary>After</summary>

```console
$ yarn build:backend

  dist/updateNote/app.js  243.0kb
  dist/createNote/app.js  242.8kb
  dist/deleteNote/app.js  242.4kb
  dist/getNote/app.js     240.6kb
  dist/listNotes/app.js   238.5kb

⚡ Done in 107ms
```

</details>

### Testing

Verified that notes application works.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
