### PR TITLE
chore(infra): remove dependency on ts-node

### DIFF
--- a/packages/infra/cdk.json
+++ b/packages/infra/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "npx ts-node cdk/aws-sdk-js-notes-app.ts"
+  "app": "node dist/aws-sdk-js-notes-app.js"
 }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "cdk": "cdk"
+    "build": "tsc",
+    "cdk": "tsc && cdk"
   },
   "devDependencies": {
     "@aws-cdk/aws-apigateway": "1.115.0",

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2018",
     "module": "commonjs",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "cdk",
+    "outDir": "dist"
   },
   "exclude": ["cdk.out"]
 }


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-notes-app/issues/46
Refs: https://github.com/TypeStrong/ts-node/issues/1427

### Description

Removes dependency on ts-node, so that it doesn't blocker in the infrastructure deployment.
The infrastructure script transpiles TS to JS before calling cdk.

### Testing

Verified that cdk commands are successful

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
