### PR TITLE
chore(deps-dev): bump crc32-stream to v4.0.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,12 +5234,12 @@ __metadata:
   linkType: hard
 
 "crc32-stream@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "crc32-stream@npm:4.0.1"
+  version: 4.0.2
+  resolution: "crc32-stream@npm:4.0.2"
   dependencies:
     crc-32: ^1.2.0
     readable-stream: ^3.4.0
-  checksum: 39c2e0d5d7a3388e85ccf27ef0b30475f98902d34e7a048decc1665ff67f98f17f850059b28942fdf5582cb836eaa5184453ec35a6ea2442ce3bc10c8f1ee8a4
+  checksum: 1099559283b86e8a55390228b57ff4d57a74cac6aa8086aa4730f84317c9f93e914aeece115352f2d706a9df7ed75327ffacd86cfe23f040aef821231b528e76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-notes-app/issues/51

Refs:
* https://github.com/aws/aws-cdk/issues/12536#issuecomment-774678334
* https://github.com/serverless/serverless/issues/8772#issuecomment-825698908

### Description

Bump crc32-stream to v4.0.2

### Testing

Verified that CDK deployments are successful.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
