### PR TITLE
[WIP] chore(frontend): replace Reach Router v1 to React Router v6

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,9 @@
     "process": "0.11.10",
     "react": "17.0.1",
     "react-bootstrap": "1.4.0",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "react-router": "6.0.2",
+    "react-router-dom": "6.0.2"
   },
   "scripts": {
     "prepare:frontend": "cd .. && yarn prepare:frontend",

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from "react";
-import { Router } from "@reach/router";
+import { Routes } from "react-router-dom";
 
 const ListNotes = lazy(() => import("./content/ListNotes"));
 const CreateNote = lazy(() => import("./content/CreateNote"));
@@ -9,12 +9,12 @@ const NotFound = lazy(() => import("./content/NotFound"));
 const Routes = () => (
   <div className="mt-md-4 d-flex flex-column justify-content-center">
     <Suspense fallback={<div>Loading...</div>}>
-      <Router>
+      <Routes>
         <ListNotes path="/" />
         <CreateNote path="/note/new" />
         <ShowNote path="/notes/:noteId" />
         <NotFound default />
-      </Router>
+      </Routes>
     </Suspense>
   </div>
 );

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import { LocationProvider } from "@reach/router";
 import { Buffer } from "buffer";
 import process from "process";
 import React from "react";
@@ -16,8 +17,10 @@ if (typeof (window as any).process === "undefined") {
 }
 
 ReactDOM.render(
-  <div className="container" style={{ height: "100vh" }}>
-    <Routes />
-  </div>,
+  <LocationProvider>
+    <div className="container" style={{ height: "100vh" }}>
+      <Routes />
+    </div>
+  </LocationProvider>,
   document.getElementById("root")
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,8 @@ __metadata:
     react-bootstrap: 1.4.0
     react-bootstrap-icons: 1.3.0
     react-dom: 17.0.1
+    react-router: 6.0.2
+    react-router-dom: 6.0.2
     typescript: ~4.4.4
     vite: 2.4.4
   languageName: unknown
@@ -2347,6 +2349,15 @@ __metadata:
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: 64964a0fd172917fc5faac56bea5f0e6ec6200973e4ed6373e114f23f8cd6f113be31a6559fadfdd4f62071559e05d00a391760876a00345ea7813356c880209
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.7.6":
+  version: 7.16.3
+  resolution: "@babel/runtime@npm:7.16.3"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: ab8ac887096d76185ddbf291d28fb976cd32473696dc497ad4905b784acbd5aa462533ad83a5c5104e10ead28c2e0e119840ee28ed8eff90dcdde9d57f916eda
   languageName: node
   linkType: hard
 
@@ -4447,6 +4458,15 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"history@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "history@npm:5.1.0"
+  dependencies:
+    "@babel/runtime": ^7.7.6
+  checksum: c978710a188ee5ad5d2acf55721c77e27469578c891a66311e71e8920d1390d14476e39a6db07e0ab0f5f8d594f1f62eb55a1059c7549cde7795a36367df5869
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.0":
   version: 4.1.0
   resolution: "http-cache-semantics@npm:4.1.0"
@@ -5884,6 +5904,30 @@ fsevents@~2.3.2:
   version: 0.10.0
   resolution: "react-refresh@npm:0.10.0"
   checksum: 089b8ea9ad8038046c0467a2476595eedab9e30620f50daa50e844c81d626de43a44a6a628256ae58e68885d5fe1d7e05074ddfd99ece3808b013d043f0c6030
+  languageName: node
+  linkType: hard
+
+"react-router-dom@npm:6.0.2":
+  version: 6.0.2
+  resolution: "react-router-dom@npm:6.0.2"
+  dependencies:
+    history: ^5.1.0
+    react-router: 6.0.2
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: d3680939a4fac286f8df028c1fabe5626567ba065b2029b1cc4ad64fe9444aeba186d0e5e765563fc36ea868e7d17e02fb098f2ebc0b1c70212a8470a4b58ad6
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.0.2":
+  version: 6.0.2
+  resolution: "react-router@npm:6.0.2"
+  dependencies:
+    history: ^5.1.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 9d4f3a8002a90f38be022c6740e11e9bb481e60ad04c5a0ce2d6dbe685059c09b3037c45414d6e7e40eb97308842380413cfb93c5cdcb992e7ee0c50b4f7fcaa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-notes-app/issues/26

### Description

Switches from Reach Router v1 to React Router v6.

### Testing

ToDo: Verify that routes work in the frontend.

### Additional context

Refs: https://reactrouter.com/docs/en/v6/upgrading/reach#first-non-breaking-updates

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
