### PR TITLE
feat(deps): bump react to v18

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,9 +17,9 @@
     "buffer": "6.0.3",
     "microphone-stream": "6.0.1",
     "process": "0.11.10",
-    "react": "17.0.1",
+    "react": "18.0.0",
     "react-bootstrap": "1.4.0",
-    "react-dom": "17.0.1"
+    "react-dom": "18.0.0"
   },
   "scripts": {
     "prepare:frontend": "cd .. && yarn prepare:frontend",

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@ __metadata:
     buffer: 6.0.3
     microphone-stream: 6.0.1
     process: 0.11.10
-    react: 17.0.1
+    react: 18.0.0
     react-bootstrap: 1.4.0
     react-bootstrap-icons: 1.3.0
-    react-dom: 17.0.1
+    react-dom: 18.0.0
     typescript: ~4.4.4
     vite: 2.4.4
   languageName: unknown
@@ -5162,16 +5162,15 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"react-dom@npm:17.0.1":
-  version: 17.0.1
-  resolution: "react-dom@npm:17.0.1"
+"react-dom@npm:18.0.0":
+  version: 18.0.0
+  resolution: "react-dom@npm:18.0.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.1
+    scheduler: ^0.21.0
   peerDependencies:
-    react: 17.0.1
-  checksum: df2af300dd4f49a5daaccc38f5a307def2a9ae2b7ebffa3dce8fb9986129057696b86a2c94e5ae36133057c69428c500e4ee3bf5884eb44e5632ace8b7ace41f
+    react: ^18.0.0
+  checksum: dd0ba9f2f31dd728076c892a95b2f5a8dfe79136431b0289afb46eec39d0ca6b6f0f40a60fd8aa6ef702c98ce7c26100d3d4dbc35c7c9e87429cd04f84cb58bd
   languageName: node
   linkType: hard
 
@@ -5230,13 +5229,12 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"react@npm:17.0.1":
-  version: 17.0.1
-  resolution: "react@npm:17.0.1"
+"react@npm:18.0.0":
+  version: 18.0.0
+  resolution: "react@npm:18.0.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: 83b9df9529a2b489f00a4eaa608fc7d55518b258e046c100344ae068713e43ae64e477a140f87e38cfe75489bcfd26d27fce5818f89f4ec41bdbda7ead4bb426
+  checksum: 293020b96536b3c7113ee57ca5c990a3f25649d1751b1c7a3aabd16dff0691fe9f1eed1206616d0906d05933536052037340a0c8d0941ff870b0eb469a2f975b
   languageName: node
   linkType: hard
 
@@ -5470,13 +5468,12 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.1":
-  version: 0.20.1
-  resolution: "scheduler@npm:0.20.1"
+"scheduler@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "scheduler@npm:0.21.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: ace896fff8ccc516a4b5a249c712fc88d4e2456587d991acc220b54690362d6a2b9d426a7f030454cb439f6f5ff2706b13ee8c44ccb953884c4756304a2f8ad6
+  checksum: 4f8285076041ed2c81acdd1faa987f1655fdbd30554bc667c1ea64743fc74fb3a04ca7d27454b3d678735df5a230137a3b84756061b43dc5796e80701b66d124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

React v18 is stable! https://reactjs.org/blog/2022/03/29/react-v18.html

### Description

Bumps react to v18

### Testing

ToDo: Local testing

### Additional context

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
