### PR TITLE
chore(infra): bump Lambda Runtime to NODEJS_16_X

### DIFF
--- a/packages/infra/cdk/notes-api.ts
+++ b/packages/infra/cdk/notes-api.ts
@@ -18,7 +18,7 @@ export class NotesApi extends Construct {
     const { table, grantActions } = props;
 
     this.handler = new lambda.Function(this, "handler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       handler: "app.handler",
       // ToDo: find a better way to pass lambda code
       code: lambda.Code.fromAsset(`../backend/dist/${id}`),


### PR DESCRIPTION
### Issue

Lambda added support for Node.js 16.x https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/

### Description

Bumps Lambda Runtime to NODEJS_16_X

### Testing

ToDo: Local testing

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
