### PR TITLE
chore: recommend running corepack enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ To set up this notes app, complete the following tasks:
 - Install **Node.js** by following these steps:
   1. Install [nvm](https://github.com/nvm-sh/nvm#installation-and-update).
   1. Use node v16.x.x by running `nvm use` or `nvm use 16` in a terminal window.
-  1. Verify that node is installed by running `node -v` in a terminal window and confirm that it shows the latest version of `v16`, such as `v16.16.0`).
-- Install [yarn](https://yarnpkg.com/en/docs/install).
-  - We recommend using **yarn** for its simplicity, speed and yarn workspaces.
+  1. Verify that node is installed by running `node -v` in a terminal window and confirm that it shows Node.js >=16.10, such as `v16.16.0`).
+  1. Enable corepack by running `corepack enable` in a terminal window.
 - Install dependencies by running `yarn`.
 - If you don't have an AWS account, [create one](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
   - If you're an Amazon employee, see the internal wiki for creating an AWS account.

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
   },
   "lint-staged": {
     "*.{ts,js,md}": "prettier --write"
-  }
+  },
+  "packageManager": "yarn@3.0.0"
 }


### PR DESCRIPTION
### Issue

Corepack has been available in Node.js since September 2021 https://dev.to/cloudx/corepack-the-node-js-manager-of-package-managers-44dd

### Description

Recommend running corepack enable for detecting yarn

### Testing

Verified that `yarn --version` is `3.0.0`

```console
$ yarn --version
3.0.0
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
