### PR TITLE
chore: recommend Node.js 18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ To set up this notes app, complete the following tasks:
 
 - Install **Node.js** by following these steps:
   1. Install [nvm](https://github.com/nvm-sh/nvm#installation-and-update).
-  1. Use node v16.x.x by running `nvm use` or `nvm use 16` in a terminal window.
-  1. Verify that node is installed by running `node -v` in a terminal window and confirm that it shows Node.js >=16.10, such as `v16.16.0`).
+  1. Use node v18.x.x by running `nvm use` or `nvm use 18` in a terminal window.
+  1. Verify that node is installed by running `node -v` in a terminal window and confirm that it shows Node.js >=18, such as `v18.13.0`).
   1. Enable corepack by running `corepack enable` in a terminal window.
 - Install dependencies by running `yarn`.
 - If you don't have an AWS account, [create one](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).

--- a/packages/backend/build.js
+++ b/packages/backend/build.js
@@ -10,7 +10,7 @@ buildSync({
   minify: true,
   outdir: "dist",
   platform: "node",
-  target: "node16",
+  target: "node18",
   mainFields: ["module", "main"],
   logLevel: "info",
 });

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.64",
-    "@types/node": "16.11.43",
+    "@types/node": "18.11.18",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
     "esbuild": "0.12.17",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.64",
-    "@types/node": "18.11.18",
+    "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
     "esbuild": "0.12.17",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "18.11.18",
+    "@types/node": "^18.11.18",
     "@types/reach__router": "1.3.6",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "16.11.43",
+    "@types/node": "18.11.18",
     "@types/reach__router": "1.3.6",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -8,7 +8,7 @@
     "cdk": "tsc && cdk"
   },
   "devDependencies": {
-    "@types/node": "16.11.43",
+    "@types/node": "18.11.18",
     "aws-cdk": "2.59.0",
     "typescript": "~4.4.4"
   },

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -8,7 +8,7 @@
     "cdk": "tsc && cdk"
   },
   "devDependencies": {
-    "@types/node": "18.11.18",
+    "@types/node": "^18.11.18",
     "aws-cdk": "2.59.0",
     "typescript": "~4.4.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,7 +146,7 @@ __metadata:
     "@aws-sdk/client-dynamodb": 3.245.0
     "@aws-sdk/util-dynamodb": 3.245.0
     "@types/aws-lambda": ^8.10.64
-    "@types/node": 18.11.18
+    "@types/node": ^18.11.18
     "@typescript-eslint/eslint-plugin": 5.3.1
     "@typescript-eslint/parser": 5.3.1
     esbuild: 0.12.17
@@ -169,7 +169,7 @@ __metadata:
     "@aws-sdk/util-create-request": 3.234.0
     "@aws-sdk/util-format-url": 3.226.0
     "@reach/router": 1.3.4
-    "@types/node": 18.11.18
+    "@types/node": ^18.11.18
     "@types/reach__router": 1.3.6
     "@types/react": ^18.0.15
     "@types/react-dom": ^18.0.6
@@ -192,7 +192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk-notes-app/infra@workspace:packages/infra"
   dependencies:
-    "@types/node": 18.11.18
+    "@types/node": ^18.11.18
     aws-cdk: 2.59.0
     aws-cdk-lib: 2.59.0
     constructs: 10.1.215
@@ -2097,7 +2097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.11.18":
+"@types/node@npm:^18.11.18":
   version: 18.11.18
   resolution: "@types/node@npm:18.11.18"
   checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,7 +146,7 @@ __metadata:
     "@aws-sdk/client-dynamodb": 3.245.0
     "@aws-sdk/util-dynamodb": 3.245.0
     "@types/aws-lambda": ^8.10.64
-    "@types/node": 16.11.43
+    "@types/node": 18.11.18
     "@typescript-eslint/eslint-plugin": 5.3.1
     "@typescript-eslint/parser": 5.3.1
     esbuild: 0.12.17
@@ -169,7 +169,7 @@ __metadata:
     "@aws-sdk/util-create-request": 3.234.0
     "@aws-sdk/util-format-url": 3.226.0
     "@reach/router": 1.3.4
-    "@types/node": 16.11.43
+    "@types/node": 18.11.18
     "@types/reach__router": 1.3.6
     "@types/react": ^18.0.15
     "@types/react-dom": ^18.0.6
@@ -192,7 +192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk-notes-app/infra@workspace:packages/infra"
   dependencies:
-    "@types/node": 16.11.43
+    "@types/node": 18.11.18
     aws-cdk: 2.59.0
     aws-cdk-lib: 2.59.0
     constructs: 10.1.215
@@ -2097,10 +2097,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.11.43":
-  version: 16.11.43
-  resolution: "@types/node@npm:16.11.43"
-  checksum: 96d09e68347c49ebf84fe1443360edc3f98336f0794256abc8e4f29ef3070546357cae17083d6fd9767b631239367c4f245fe64accff4af057d17bd6694f0b2b
+"@types/node@npm:18.11.18":
+  version: 18.11.18
+  resolution: "@types/node@npm:18.11.18"
+  checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/aws-samples/aws-sdk-js-notes-app/pull/68
* Node.js 18.x went LTS on 2022-10-25 https://github.com/nodejs/release#release-schedule
* We bumped Lambda to Node.js 18.x in https://github.com/aws-samples/aws-sdk-js-notes-app/pull/87

### Description

Recommend Node.js 18.x

### Testing

Local testing

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
