### PR TITLE
chore(infra): bump Lambda Runtime to NODEJS_18_X

### DIFF
--- a/packages/infra/cdk/notes-api.ts
+++ b/packages/infra/cdk/notes-api.ts
@@ -18,7 +18,7 @@ export class NotesApi extends Construct {
     const { table, grantActions } = props;
 
     this.handler = new lambda.Function(this, "handler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       handler: "app.handler",
       // ToDo: find a better way to pass lambda code
       code: lambda.Code.fromAsset(`../backend/dist/${id}`),


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/aws-samples/aws-sdk-js-notes-app/pull/67
Lambda added support for Node.js 18.x https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/

### Description

Bump Lambda Runtime to NODEJS_18_X

### Testing

Verified that backend is deployed on Node.js 18 functions, and works with frontend.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
