### PR TITLE
chore: bundle aws-sdk dependencies from workspace

### DIFF
--- a/packages/infra/cdk/backend/notes-api.ts
+++ b/packages/infra/cdk/backend/notes-api.ts
@@ -22,6 +22,7 @@ export class NotesApi extends Construct {
 
     this.handler = new lambda.NodejsFunction(this, id, {
       environment: { NOTES_TABLE_NAME: table.tableName },
+      bundling: { externalModules: [] },
     });
 
     // grant the lambda role read/write permissions to notes table


### PR DESCRIPTION
### Issue

By default, the AWS CDK Lambda Node.js function uses Lambda Provided SDK
https://github.com/aws/aws-cdk/issues/25492

### Description

Bundle aws-sdk dependencies from workspace

### Testing

Noticed that there are no changes while doing CDK deploy

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
