### PR TITLE
chore(frontend): use ESM module

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -65,5 +65,6 @@
     "react-bootstrap-icons": "1.3.0",
     "typescript": "~4.9.4",
     "vite": "5.2.7"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
### Issue

Vite CJS Node API deprecated, and will be removed in Vite 6
Docs: https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated

### Description

Use ESM module in frontend 

### Testing

Local testing

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
