### PR TITLE
Remove eslint-disable-next-line no-unused-vars

### DIFF
--- a/packages/infra/cdk/backend/notes-api.create.ts
+++ b/packages/infra/cdk/backend/notes-api.create.ts
@@ -2,9 +2,7 @@ import crypto from "crypto";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { success, failure } from "./libs/response";
-
-// eslint-disable-next-line no-unused-vars
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 

--- a/packages/infra/cdk/backend/notes-api.delete.ts
+++ b/packages/infra/cdk/backend/notes-api.delete.ts
@@ -1,9 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { success, failure } from "./libs/response";
-
-// eslint-disable-next-line no-unused-vars
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 

--- a/packages/infra/cdk/backend/notes-api.get.ts
+++ b/packages/infra/cdk/backend/notes-api.get.ts
@@ -1,9 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { success, failure } from "./libs/response";
-
-// eslint-disable-next-line no-unused-vars
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 

--- a/packages/infra/cdk/backend/notes-api.update.ts
+++ b/packages/infra/cdk/backend/notes-api.update.ts
@@ -1,9 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { success, failure } from "./libs/response";
-
-// eslint-disable-next-line no-unused-vars
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 


### PR DESCRIPTION
### Issue

N/A

### Description

Remove eslint-disable-next-line no-unused-vars, by doing type imports

### Testing

Build is successful

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
