### PR TITLE
Bump typescript to ~5.4.5

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -59,7 +59,7 @@
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react-refresh": "1.3.6",
     "react-bootstrap-icons": "1.3.0",
-    "typescript": "~4.9.4",
+    "typescript": "~5.4.5",
     "vite": "5.2.7"
   },
   "type": "module"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -11,7 +11,7 @@
     "@types/aws-lambda": "^8.10.64",
     "@types/node": "^18.11.18",
     "aws-cdk": "2.134.0",
-    "typescript": "~4.9.4"
+    "typescript": "~5.4.5"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.348.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,7 +153,7 @@ __metadata:
     react-bootstrap: "npm:1.4.0"
     react-bootstrap-icons: "npm:1.3.0"
     react-dom: "npm:18.2.0"
-    typescript: "npm:~4.9.4"
+    typescript: "npm:~5.4.5"
     vite: "npm:5.2.7"
   languageName: unknown
   linkType: soft
@@ -169,7 +169,7 @@ __metadata:
     aws-cdk: "npm:2.134.0"
     aws-cdk-lib: "npm:2.134.0"
     constructs: "npm:10.3.0"
-    typescript: "npm:~4.9.4"
+    typescript: "npm:~5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -4719,23 +4719,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:~5.4.5":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
+  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~4.9.4#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
+  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/

### Description

Bump typescript to ~5.4.5

### Testing

Local testing

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
