### PR TITLE
docs: specify credentials file and show location in brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To set up this notes app, complete the following tasks:
     [default]
     region = us-west-2
     ```
+
 ## Setup
 
 This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as follows:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ To set up this notes app, complete the following tasks:
     [default]
     region = us-west-2
     ```
-For more information on the location of the credential and configuration files, see the [AWS documentation on file locations](https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html).
 ## Setup
 
 This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as follows:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To set up this notes app, complete the following tasks:
 - Install the [AWS CLI](https://aws.amazon.com/cli/).
   - Verify that the AWS CLI is installed by running `aws` in a terminal window.
 - Set up [AWS Shared Credential File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
-  - Your credentials (`~/.aws/credentials` on Mac/Linux,`%UserProfile%\.aws\credentials` on Windows) should look like the following:
+  - Your credentials file (`~/.aws/credentials` on Mac/Linux,`%UserProfile%\.aws\credentials` on Windows) should look like the following:
     ```
     [default]
     aws_access_key_id = <ACCESS_KEY>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To set up this notes app, complete the following tasks:
 - Install the [AWS CLI](https://aws.amazon.com/cli/).
   - Verify that the AWS CLI is installed by running `aws` in a terminal window.
 - Set up [AWS Shared Credential File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
-  - Your `~/.aws/credentials` (`%UserProfile%\.aws\credentials` on Windows) should look like the following:
+  - Your credentials (`~/.aws/credentials` on Mac/Linux,`%UserProfile%\.aws\credentials` on Windows) should look like the following:
     ```
     [default]
     aws_access_key_id = <ACCESS_KEY>
@@ -44,7 +44,7 @@ To set up this notes app, complete the following tasks:
     [default]
     region = us-west-2
     ```
-
+For more information on the location of the credential and configuration files, see the [AWS documentation on file locations](https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html).
 ## Setup
 
 This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as follows:


### PR DESCRIPTION
delineated cred locations per OS and added link to AWS docs

### Issue

Refs: #, if available

### Description

What does this implement/fix? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
