### PR TITLE
Add cdk bootstrap cmd before cdk deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as 
 - backend performs create, delete, get, list and update operations on DynamoDB.
 - frontend does put, get, delete operations using an S3 browser client.
 
-- Run: `cdk bootstrap aws://[aws-account-ID/[region]` 
+- Run: `cdk bootstrap aws://[aws-account-ID]/[region]` 
 - This command:
   - Creates a CloudFormation stack in the environment.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as 
 - backend performs create, delete, get, list and update operations on DynamoDB.
 - frontend does put, get, delete operations using an S3 browser client.
 
-Use `cdk bootstrap aws://[aws-account-ID/[region]` 
-The bootstrap command creates a CloudFormation stack in the environment passed on the command line.
+- Run: `cdk bootstrap aws://[aws-account-ID/[region]` 
+- This command:
+  - Creates a CloudFormation stack in the environment.
 
 ### Deploy infrastructure
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ This exercise code uses [modular AWS SDK for JavaScript][modular-aws-sdk-js] as 
 - backend performs create, delete, get, list and update operations on DynamoDB.
 - frontend does put, get, delete operations using an S3 browser client.
 
+Use `cdk bootstrap aws://[aws-account-ID/[region]` 
+The bootstrap command creates a CloudFormation stack in the environment passed on the command line.
+
 ### Deploy infrastructure
 
 - Run: `yarn cdk deploy`


### PR DESCRIPTION
### Issue
`aws-sdk-js-notes-app: SSM parameter /cdk-bootstrap/hnb659fds/version not found. Has the environment been bootstrapped? Please run 'cdk bootstrap' (see https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html)`

Refs: #, if available

### Description

What does this implement/fix? Explain your changes.
When I ran it without `cdk bootstrap` specified, I couldn't deploy it and it states this error. Once I used this command and continued with the README, it deployed properly.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
